### PR TITLE
docs(star-prnt): correct capitalization of example code

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/star-prnt/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/star-prnt/index.ts
@@ -634,7 +634,7 @@ export type CommandsArray = Array<PrintCommand>;
  * ...
  *
  *
- * this.starprnt.portDiscovery('all')
+ * this.starprnt.portDiscovery('All')
  *   .then((res: any) => console.log(res))
  *   .catch((error: any) => console.error(error));
  *


### PR DESCRIPTION
Based on reading [the underlying source](https://github.com/auctifera-josed/starprnt/blob/master/src/ios/StarPRNT.m)