### PR TITLE
docs(email-composer): update example

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/email-composer/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/email-composer/index.ts
@@ -67,7 +67,7 @@ export interface EmailComposerOptions {
  *    // Returns an array of configured email clients for the device
  * });
  *
- * this.emailComposer.hasClient().then(app, (isValid: boolean) => {
+ * this.emailComposer.hasClient(app).then((isValid: boolean) => {
  *  if (isValid) {
  *    // Now we know we have a valid email client configured
  *    // Not specifying an app will return true if at least one email client is configured
@@ -80,7 +80,7 @@ export interface EmailComposerOptions {
  *  }
  * });
  *
- * this.emailComposer.isAvailable().then(app, (available: boolean) => {
+ * this.emailComposer.isAvailable(app).then((available: boolean) => {
  *  if(available) {
  *    // Now we know we can send an email, calls hasClient and hasAccount
  *    // Not specifying an app will return true if at least one email client is configured


### PR DESCRIPTION
"this.emailComposer.hasClient()" and "this.emailComposer.isAvailable()" method usage is wrong on the official documentation. Please check.
.hasClient and .isAvailable both requires an app name string as the parameter, and they return promises. 
The original code of putting the parameter "app" into the "then()" chainable is not correct, as the "then()" only accepts callback functions as parameters.
Tested and proved in visual studio code.