### PR TITLE
fix(keychain): mark useTouchID as required

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/keychain/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/keychain/index.ts
@@ -17,7 +17,7 @@ import { Cordova, AwesomeCordovaNativePlugin, Plugin } from '@awesome-cordova-pl
  *
  * ...
  *
- * this.keychain.set(key, value).then(() => {
+ * this.keychain.set(key, value, false).then(() => {
  *   this.keychain.get(key)
  *     .then(value => console.log('Got value', value))
  *     .catch(err => console.error('Error getting', err));
@@ -57,7 +57,7 @@ export class Keychain extends AwesomeCordovaNativePlugin {
   @Cordova({
     callbackOrder: 'reverse',
   })
-  set(key: string, value: string | number | boolean, useTouchID?: boolean): Promise<any> {
+  set(key: string, value: string | number | boolean, useTouchID: boolean): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
`useTouchID` is not an optional parameter. When it is not explicitly set, the whole app crashes with this error:
> Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull boolValue]: unrecognized selector sent to instance 0x111f02f08'

This bug is [known](https://github.com/ionic-team/cordova-plugin-ios-keychain/issues/34) since November 2018 and likely won't be fixed.