### PR TITLE
update to create ivy distribution (#3976)

### DIFF
--- a/tsconfig.core.json
+++ b/tsconfig.core.json
@@ -17,5 +17,9 @@
     "sourceMap": true
   },
   "include": ["src/@awesome-cordova-plugins/core/**/*.ts"],
-  "exclude": ["node_modules", "src/@awesome-cordova-plugins/core/**/*.spec.ts"]
+  "exclude": ["node_modules", "src/@awesome-cordova-plugins/core/**/*.spec.ts"],
+  "angularCompilerOptions": {
+    "genDir": "aot",
+    "compilationMode": "partial"
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
   },
   "include": ["src/@awesome-cordova-plugins/plugins/**/*.ts"],
   "angularCompilerOptions": {
-    "genDir": "aot"
+    "genDir": "aot",
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
Small change to create ivy distribution for angular.  All tests still pass.

Have tested locally with my own apps and seems to be working well and the notice about legacy view engine libraries is resolved (as shown in #3976).

Build is set to Ivy Partial mode for compatibility for public projects as per the angular docs.  Partial mode ensures that an exact match of library versions and angular project versions is not required.