### PR TITLE
fix(themeable-browser):update option type

### DIFF
--- a/src/@ionic-native/plugins/themeable-browser/index.ts
+++ b/src/@ionic-native/plugins/themeable-browser/index.ts
@@ -64,7 +64,7 @@ export interface ThemeableBrowserOptions {
   presentationstyle?: string;
   transitionstyle?: string;
   toolbarposition?: string;
-  fullscreen?: string;
+  fullscreen?: boolean;
 }
 
 /**


### PR DESCRIPTION
the type of fullscreen property actually is boolean, if the prop set to string 'true', it will cause parseFeature() method throw exception and create an new default Options class

https://github.com/initialxy/cordova-plugin-themeablebrowser/blob/master/src/android/ThemeableBrowser.java#L1406