### PR TITLE
[sms-retriever] Updating the types to match what we get

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/sms-retriever/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/sms-retriever/index.ts
@@ -41,7 +41,7 @@ export class SmsRetriever extends AwesomeCordovaNativePlugin {
    * @returns {Promise<string>} Returns a promise that resolves when retrives SMS text or TIMEOUT after 5 min.
    */
   @Cordova()
-  startWatching(): Promise<string> {
+  startWatching(): Promise<{ Message?: string }> {
     return;
   }
 


### PR DESCRIPTION
When getting the message we get an object containing `Message` with the content.