### PR TITLE
Use ivy for ngx packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,16 +6,16 @@
   "packages": {
     "": {
       "name": "awesome-cordova-plugins",
-      "version": "5.45.0",
+      "version": "5.46.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.4.0"
       },
       "devDependencies": {
-        "@angular/common": "11.2.14",
-        "@angular/compiler": "11.2.14",
-        "@angular/compiler-cli": "11.2.14",
-        "@angular/core": "11.2.14",
+        "@angular/common": "12.2.16",
+        "@angular/compiler": "12.2.16",
+        "@angular/compiler-cli": "12.2.16",
+        "@angular/core": "12.2.16",
         "@types/cordova": "0.0.34",
         "@types/fs-extra": "9.0.13",
         "@types/jest": "27.5.2",
@@ -50,7 +50,7 @@
         "terser-webpack-plugin": "5.3.6",
         "ts-jest": "27.1.5",
         "ts-node": "10.9.1",
-        "typescript": "4.1.6",
+        "typescript": "4.2.4",
         "unminified-webpack-plugin": "3.0.0",
         "webpack": "5.74.0",
         "winston": "3.8.2",
@@ -58,31 +58,37 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "11.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-11.2.14.tgz",
-      "integrity": "sha512-ZSLV/3j7eCTyLf/8g4yBFLWySjiLz3vLJAGWscYoUpnJWMnug1VRu6zoF/COxCbtORgE+Wz6K0uhfS6MziBGVw==",
+      "version": "12.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.2.16.tgz",
+      "integrity": "sha512-FEqTXTEsnbDInqV1yFlm97Tz1OFqZS5t0TUkm8gzXRgpIce/F/jLwAg0u1VQkgOsno6cNm0xTWPoZgu85NI4ug==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "11.2.14",
-        "rxjs": "^6.5.3"
+        "@angular/core": "12.2.16",
+        "rxjs": "^6.5.3 || ^7.0.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "11.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-11.2.14.tgz",
-      "integrity": "sha512-XBOK3HgA+/y6Cz7kOX4zcJYmgJ264XnfcbXUMU2cD7Ac+mbNhLPKohWrEiSWalfcjnpf5gRfufQrQP7lpAGu0A==",
+      "version": "12.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.2.16.tgz",
+      "integrity": "sha512-nsYEw+yu8QyeqPf9nAmG419i1mtGM4v8+U+S3eQHQFXTgJzLymMykWHYu2ETdjUpNSLK6xcIQDBWtWnWSfJjAA==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "11.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-11.2.14.tgz",
-      "integrity": "sha512-A7ltnCp03/EVqK/Q3tVUDsokgz5GHW3dSPGl0Csk7Ys5uBB9ibHTmVt4eiXA4jt0+6Bk+mKxwe5BEDqLvwYFAg==",
+      "version": "12.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-12.2.16.tgz",
+      "integrity": "sha512-tlalh8SJvdCWbUPRUR5GamaP+wSc/GuCsoUZpSbcczGKgSlbaEVXUYtVXm8/wuT6Slk2sSEbRs7tXGF2i7qxVw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.8.6",
@@ -90,16 +96,15 @@
         "canonical-path": "1.0.0",
         "chokidar": "^3.0.0",
         "convert-source-map": "^1.5.1",
-        "dependency-graph": "^0.7.2",
-        "fs-extra": "4.0.2",
+        "dependency-graph": "^0.11.0",
         "magic-string": "^0.25.0",
         "minimist": "^1.2.0",
         "reflect-metadata": "^0.1.2",
-        "semver": "^6.3.0",
+        "semver": "^7.0.0",
         "source-map": "^0.6.1",
         "sourcemap-codec": "^1.4.8",
-        "tslib": "^2.0.0",
-        "yargs": "^16.2.0"
+        "tslib": "^2.2.0",
+        "yargs": "^17.0.0"
       },
       "bin": {
         "ivy-ngcc": "ngcc/main-ivy-ngcc.js",
@@ -108,53 +113,106 @@
         "ngcc": "ngcc/main-ngcc.js"
       },
       "engines": {
-        "node": ">=10.0"
+        "node": "^12.14.1 || >=14.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "11.2.14",
-        "typescript": ">=4.0 <4.2"
+        "@angular/compiler": "12.2.16",
+        "typescript": ">=4.2.3 <4.4"
       }
     },
-    "node_modules/@angular/compiler-cli/node_modules/fs-extra": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-      "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+    "node_modules/@angular/compiler-cli/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "node_modules/@angular/compiler-cli/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@angular/compiler-cli/node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+    "node_modules/@angular/compiler-cli/node_modules/dependency-graph": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+      "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
       "dev": true,
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/@angular/compiler-cli/node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@angular/compiler-cli/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@angular/compiler-cli/node_modules/yargs": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+      "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@angular/compiler-cli/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@angular/core": {
-      "version": "11.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-11.2.14.tgz",
-      "integrity": "sha512-vpR4XqBGitk1Faph37CSpemwIYTmJ3pdIVNoHKP6jLonpWu+0azkchf0f7oD8/2ivj2F81opcIw0tcsy/D/5Vg==",
+      "version": "12.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.2.16.tgz",
+      "integrity": "sha512-jsmvaRdAfng99z2a9mAmkfcsCE1wm+tBYVDxnc5JquSXznwtncjzcoc2X0J0dzrkCDvzFfpTsZ9vehylytBc+A==",
       "dev": true,
       "dependencies": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.14.1 || >=14.0.0"
       },
       "peerDependencies": {
-        "rxjs": "^6.5.3",
-        "zone.js": "^0.10.2 || ^0.11.3"
+        "rxjs": "^6.5.3 || ^7.0.0",
+        "zone.js": "~0.11.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -15783,9 +15841,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.6.tgz",
-      "integrity": "sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -16642,27 +16700,27 @@
   },
   "dependencies": {
     "@angular/common": {
-      "version": "11.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-11.2.14.tgz",
-      "integrity": "sha512-ZSLV/3j7eCTyLf/8g4yBFLWySjiLz3vLJAGWscYoUpnJWMnug1VRu6zoF/COxCbtORgE+Wz6K0uhfS6MziBGVw==",
+      "version": "12.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-12.2.16.tgz",
+      "integrity": "sha512-FEqTXTEsnbDInqV1yFlm97Tz1OFqZS5t0TUkm8gzXRgpIce/F/jLwAg0u1VQkgOsno6cNm0xTWPoZgu85NI4ug==",
       "dev": true,
       "requires": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
       }
     },
     "@angular/compiler": {
-      "version": "11.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-11.2.14.tgz",
-      "integrity": "sha512-XBOK3HgA+/y6Cz7kOX4zcJYmgJ264XnfcbXUMU2cD7Ac+mbNhLPKohWrEiSWalfcjnpf5gRfufQrQP7lpAGu0A==",
+      "version": "12.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-12.2.16.tgz",
+      "integrity": "sha512-nsYEw+yu8QyeqPf9nAmG419i1mtGM4v8+U+S3eQHQFXTgJzLymMykWHYu2ETdjUpNSLK6xcIQDBWtWnWSfJjAA==",
       "dev": true,
       "requires": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
       }
     },
     "@angular/compiler-cli": {
-      "version": "11.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-11.2.14.tgz",
-      "integrity": "sha512-A7ltnCp03/EVqK/Q3tVUDsokgz5GHW3dSPGl0Csk7Ys5uBB9ibHTmVt4eiXA4jt0+6Bk+mKxwe5BEDqLvwYFAg==",
+      "version": "12.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-12.2.16.tgz",
+      "integrity": "sha512-tlalh8SJvdCWbUPRUR5GamaP+wSc/GuCsoUZpSbcczGKgSlbaEVXUYtVXm8/wuT6Slk2sSEbRs7tXGF2i7qxVw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.8.6",
@@ -16670,53 +16728,84 @@
         "canonical-path": "1.0.0",
         "chokidar": "^3.0.0",
         "convert-source-map": "^1.5.1",
-        "dependency-graph": "^0.7.2",
-        "fs-extra": "4.0.2",
+        "dependency-graph": "^0.11.0",
         "magic-string": "^0.25.0",
         "minimist": "^1.2.0",
         "reflect-metadata": "^0.1.2",
-        "semver": "^6.3.0",
+        "semver": "^7.0.0",
         "source-map": "^0.6.1",
         "sourcemap-codec": "^1.4.8",
-        "tslib": "^2.0.0",
-        "yargs": "^16.2.0"
+        "tslib": "^2.2.0",
+        "yargs": "^17.0.0"
       },
       "dependencies": {
-        "fs-extra": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.2.tgz",
-          "integrity": "sha1-+RcExT0bRh+JNFKwwwfZmXZHq2s=",
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
           }
         },
-        "jsonfile": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+        "dependency-graph": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.11.0.tgz",
+          "integrity": "sha512-JeMq7fEshyepOWDfcfHK06N3MhyPhz++vtqWhMT5O9A3K42rdsEDpfdVqjaqaAhsw6a+ZqeDvQVtD0hFHQWrzg==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "lru-cache": "^6.0.0"
           }
         },
-        "universalify": {
-          "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "yargs": {
+          "version": "17.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.0.tgz",
+          "integrity": "sha512-8H/wTDqlSwoSnScvV2N/JHfLWOKuh5MVla9hqLjK3nsfyy6Y4kDSYSvkU5YCUEPOSnRXfIyx3Sq+B/IWudTo4g==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true
         }
       }
     },
     "@angular/core": {
-      "version": "11.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-11.2.14.tgz",
-      "integrity": "sha512-vpR4XqBGitk1Faph37CSpemwIYTmJ3pdIVNoHKP6jLonpWu+0azkchf0f7oD8/2ivj2F81opcIw0tcsy/D/5Vg==",
+      "version": "12.2.16",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-12.2.16.tgz",
+      "integrity": "sha512-jsmvaRdAfng99z2a9mAmkfcsCE1wm+tBYVDxnc5JquSXznwtncjzcoc2X0J0dzrkCDvzFfpTsZ9vehylytBc+A==",
       "dev": true,
       "requires": {
-        "tslib": "^2.0.0"
+        "tslib": "^2.2.0"
       }
     },
     "@babel/code-frame": {
@@ -28846,9 +28935,9 @@
       }
     },
     "typescript": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.6.tgz",
-      "integrity": "sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "tslib": "2.4.0"
   },
   "devDependencies": {
-    "@angular/common": "11.2.14",
-    "@angular/compiler": "11.2.14",
-    "@angular/compiler-cli": "11.2.14",
-    "@angular/core": "11.2.14",
+    "@angular/common": "12.2.16",
+    "@angular/compiler": "12.2.16",
+    "@angular/compiler-cli": "12.2.16",
+    "@angular/core": "12.2.16",
     "@types/cordova": "0.0.34",
     "@types/fs-extra": "9.0.13",
     "@types/jest": "27.5.2",
@@ -65,7 +65,7 @@
     "terser-webpack-plugin": "5.3.6",
     "ts-jest": "27.1.5",
     "ts-node": "10.9.1",
-    "typescript": "4.1.6",
+    "typescript": "4.2.4",
     "unminified-webpack-plugin": "3.0.0",
     "webpack": "5.74.0",
     "winston": "3.8.2",

--- a/scripts/build/ngx.ts
+++ b/scripts/build/ngx.ts
@@ -21,7 +21,8 @@ export function getProgram(rootNames: string[] = createSourceFiles()) {
   options.inlineSourceMap = true;
   options.importHelpers = true;
   options.inlineSources = true;
-  options.enableIvy = false;
+  options.enableIvy = true;
+  options.compilationMode = 'partial';
 
   delete options.baseUrl;
 
@@ -75,38 +76,6 @@ export function generateLegacyBundles() {
       })
     )
   );
-}
-
-// remove reference to @awesome-cordova-plugins/core decorators
-export function modifyMetadata() {
-  PLUGIN_PATHS.map((p) =>
-    p.replace(join(ROOT, 'src'), join(ROOT, 'dist')).replace('index.ts', 'ngx/index.metadata.json')
-  ).forEach((p) => {
-    const content = readJSONSync(p);
-    let _prop: { members: { [x: string]: any[] } };
-    for (const prop in content[0].metadata) {
-      _prop = content[0].metadata[prop];
-      removeIonicNativeDecorators(_prop);
-
-      if (_prop.members) {
-        for (const memberProp in _prop.members) {
-          removeIonicNativeDecorators(_prop.members[memberProp][0]);
-        }
-      }
-    }
-
-    writeJSONSync(p, content);
-  });
-}
-
-function removeIonicNativeDecorators(node: any) {
-  if (node.decorators && node.decorators.length) {
-    node.decorators = node.decorators.filter(
-      (d: { expression: { module: string } }) => d.expression.module !== '@awesome-cordova-plugins/core'
-    );
-  }
-
-  if (node.decorators && !node.decorators.length) delete node.decorators;
 }
 
 function createSourceFiles(): string[] {

--- a/scripts/tasks/build-ngx.ts
+++ b/scripts/tasks/build-ngx.ts
@@ -2,7 +2,6 @@ import {
   cleanupNgx,
   generateLegacyBundles,
   generateDeclarationFiles,
-  modifyMetadata,
   transpileNgx,
   transpileNgxCore,
 } from '../build/ngx';
@@ -11,5 +10,4 @@ transpileNgxCore();
 transpileNgx();
 generateLegacyBundles();
 generateDeclarationFiles();
-modifyMetadata();
 cleanupNgx();


### PR DESCRIPTION
This should switch the ngx packages to use angular ivy output.
(Related to #3976, #4198, #4215)

This change will probably break usage of the plugins in apps using older angular version (<=9 i think) and apps disabling ivy.
It did some testing with small angular test apps using v12 & v14 - which worked as expected (apps still working & ngcc is no longer required).

