### PR TITLE
feat(ble): addwrapper for starting location notifications

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/ble/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/ble/index.ts
@@ -565,6 +565,37 @@ export class BLE extends AwesomeCordovaNativePlugin {
   }
 
   /**
+   * Registers to be notified when Location service state changes on the device.
+   *
+   * @usage
+   * ```
+   * ble.startLocationStateNotifications(success, failure);
+   * // Or using await with promises
+   * // Note, initial promise resolves or rejects depending on whether the subscribe was successful
+   * await ble.withPromises.startLocationStateNotifications(success, failure)
+   * ```
+   * @returns {Observable<any>} Returns an Observable that notifies when Location is enabled or disabled on the device.
+   */
+  @Cordova({
+    observable: true,
+    clearFunction: 'stopLocationStateNotifications',
+    clearWithArgs: false,
+  })
+  startLocationStateNotifications(): Observable<any> {
+    return;
+  }
+
+  /**
+   * Stop location state notifications.
+   *
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  stopLocationStateNotifications(): Promise<any> {
+    return;
+  }
+
+  /**
    * Open System Bluetooth settings (Android only).
    *
    * @returns {Promise<any>}


### PR DESCRIPTION
Hello! noticed this function was missing, I added it in my own fork and its working as expected, figured I would open a PR to the upstream. 