### PR TITLE
feat(power-management): add power management support

### DIFF
--- a/docs/plugins/power-management.md
+++ b/docs/plugins/power-management.md
@@ -1,0 +1,19 @@
+# Power Management
+
+```text
+$ ionic cordova plugin add cordova-plugin-powermanagement
+$ npm install @awesome-cordova-plugins/power-management
+```
+
+## [Usage Documentation](https://github.com/Viras-/cordova-plugin-powermanagement/)
+
+Plugin Repo: [https://github.com/Viras-/cordova-plugin-powermanagement](https://github.com/Viras-/cordova-plugin-powermanagement)
+
+A Cordova plugin that offers access to the devices power-management functionality.
+It should be used for applications which keep running for a long time without any user interaction.
+
+## Supported platforms
+
+* Android
+* iOS
+

--- a/docs/plugins/power-management/power-management.md
+++ b/docs/plugins/power-management/power-management.md
@@ -1,0 +1,19 @@
+# Power Management
+
+```text
+$ ionic cordova plugin add cordova-plugin-powermanagement
+$ npm install @awesome-cordova-plugins/power-management
+```
+
+## [Usage Documentation](https://github.com/Viras-/cordova-plugin-powermanagement/)
+
+Plugin Repo: [https://github.com/Viras-/cordova-plugin-powermanagement](https://github.com/Viras-/cordova-plugin-powermanagement)
+
+A Cordova plugin that offers access to the devices power-management functionality.
+It should be used for applications which keep running for a long time without any user interaction.
+
+## Supported platforms
+
+* Android
+* iOS
+

--- a/src/@awesome-cordova-plugins/plugins/power-management/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/power-management/index.ts
@@ -1,0 +1,68 @@
+import { Injectable } from '@angular/core';
+import { Cordova, AwesomeCordovaNativePlugin, Plugin } from '@awesome-cordova-plugins/core';
+/**
+ * @name Power Management
+ * @description
+ * The PowerManagement plugin offers access to the devices power-management functionality.
+ * It should be used for applications which keep running for a long time without any user interaction.
+ * @usage
+ * ```
+ * import { PowerManagement } from '@awesome-cordova-plugins/power-management/ngx';
+ *
+ * constructor(private powerManagement: PowerManagement) { }
+ *
+ * ...
+ *
+ * this.powerManagement.acquire()
+ *   .then(onSuccess)
+ *   .catch(onError);
+ *
+ * ```
+ */
+@Plugin({
+  pluginName: 'PowerManagement',
+  plugin: 'cordova-plugin-powermanagement-orig',
+  pluginRef: 'powerManagement',
+  repo: 'https://github.com/Viras-/cordova-plugin-powermanagement',
+  platforms: ['Android', 'iOS'],
+})
+@Injectable()
+export class PowerManagement extends AwesomeCordovaNativePlugin {
+  /**
+   * Acquire a wakelock by calling this.
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  acquire(): Promise<any> {
+    return;
+  }
+
+  /**
+   * This acquires a partial wakelock, allowing the screen to be dimmed.
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  dim(): Promise<any> {
+    return;
+  }
+
+  /**
+   * Release the wakelock. It's important to do this when you're finished with the wakelock, to avoid unnecessary battery drain.
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  release(): Promise<any> {
+    return;
+  }
+
+  /**
+   * By default, the plugin will automatically release a wakelock when your app is paused (e.g. when the screen is turned off, or the user switches to another app).
+   * It will reacquire the wakelock upon app resume. If you would prefer to disable this behaviour, you can use this function.
+   * @param set {boolean}
+   * @returns {Promise<any>}
+   */
+  @Cordova()
+  setReleaseOnPause(set: boolean): Promise<any> {
+    return;
+  }
+}


### PR DESCRIPTION
Hi.
I just rescue this "old" wrapper (@ionic-native) witch I'm still using with cordova and capacitor.

I don't know why this wrapper was dropped out... I found the old PR (https://github.com/danielsogl/awesome-cordova-plugins/pull/489)

I tested this new and updated code, compiled and installed locally
and all work like as expected