### PR TITLE
chore(README): point to official plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You also need to install the Awesome Cordova Plugins package for each plugin you
 
 ## Documentation
 
-For the full Awesome Cordova Plugins documentation, please visit [https://ionicframework.com/docs/native/](https://ionicframework.com/docs/native/).
+For the full Awesome Cordova Plugins documentation, please visit [https://danielsogl.gitbook.io/awesome-cordova-plugins](https://danielsogl.gitbook.io/awesome-cordova-plugins).
 
 ### Basic Usage
 


### PR DESCRIPTION
While googling a cordova plugin I found this official docs https://danielsogl.gitbook.io/awesome-cordova-plugins/

Changed the link on the README since Ionic docs are not showing the cordova plugins anymore but showing Capacitor plugins

closes https://github.com/danielsogl/awesome-cordova-plugins/issues/4487