### PR TITLE
fix(text-to-speech-advanced): use promise-based API for tts-advanced

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/text-to-speech-advanced/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/text-to-speech-advanced/index.ts
@@ -62,8 +62,7 @@ export class TextToSpeechAdvanced extends AwesomeCordovaNativePlugin {
    * @returns {Promise<any>} Returns a promise that resolves when the speaking finishes
    */
   @Cordova({
-    successIndex: 1,
-    errorIndex: 2,
+    otherPromise: true
   })
   speak(textOrOptions: string | TTSOptions): Promise<any> {
     return;
@@ -74,7 +73,9 @@ export class TextToSpeechAdvanced extends AwesomeCordovaNativePlugin {
    *
    * @returns {Promise<any>}
    */
-  @Cordova()
+  @Cordova({
+    otherPromise: true
+  })
   stop(): Promise<any> {
     return;
   }
@@ -84,7 +85,9 @@ export class TextToSpeechAdvanced extends AwesomeCordovaNativePlugin {
    *
    * @returns {Promise<TTSVoice[]>}
    */
-  @Cordova()
+  @Cordova({
+    otherPromise: true
+  })
   getVoices(): Promise<TTSVoice[]> {
     return;
   }


### PR DESCRIPTION
The Cordova API of [`cordova-plugin-tts-advanced`](https://www.npmjs.com/package/cordova-plugin-tts-advanced) changed from a callback-based one to a promise-based one. This pull request adds the `otherPromise` configuration option to the appropriate `@Cordova` decorators in `text-to-speech-advanced/index.ts`.

Fixes issue #4425