### PR TITLE
feat(urbanairship): add plugin

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/urbanairship/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/urbanairship/index.ts
@@ -1181,4 +1181,45 @@ export class UrbanAirShip extends AwesomeCordovaNativePlugin {
   openPreferenceCenter(prenferenceCenterId: string): Promise<any> {
     return;
   }
+
+  /**
+   * Overrides the locale setting.
+   *
+   * @param {string} locale language and optional country code.
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   * @since 14.3.0
+   */
+  @Cordova()
+  setCurrentLocale(locale: string): Promise<any> {
+    return;
+  }
+
+  /**
+   * Returns the currently set locale.
+   *
+   * @param {function(locale)} [success] Success callback.
+   * @param {string} success.locale The locale as a string.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   * @since 14.3.0
+   */
+  @Cordova()
+  getCurrentLocale(): Promise<string> {
+    return;
+  }
+
+  /**
+   * Resets the current locale.
+   *
+   * @param {function} [success] Success callback.
+   * @param {function(message)} [failure] Failure callback.
+   * @param {string} failure.message The error message.
+   * @since 14.3.0
+   */
+  @Cordova()
+  clearLocale(): Promise<any> {
+    return;
+  }
 }


### PR DESCRIPTION
The Airship SDK now supports overriding the default locale, this was added in https://github.com/urbanairship/urbanairship-cordova/pull/399

I would like to add these methods here as well.