### PR TITLE
Use jwtToken instead of appKey and appSecret to initialize Zoom Meeting SDK

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/zoom/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/zoom/index.ts
@@ -15,7 +15,7 @@ import { Cordova, AwesomeCordovaNativePlugin, Plugin } from '@awesome-cordova-pl
  * ...
  *
  * // Initialize Zoom SDK, need to be called when app fired up.
- * this.zoomService.initialize(API_KEY, API_SECRET)
+ * this.zoomService.initialize(JWT_TOKEN)
  *   .then((success: any) => console.log(success))
  *   .catch((error: any) => console.log(error));
  *
@@ -88,12 +88,11 @@ export class Zoom extends AwesomeCordovaNativePlugin {
   /**
    * Initialize Zoom SDK.
    *
-   * @param appKey    Zoom SDK app key.
-   * @param appSecret Zoom SDK app secret.
+   * @param jwtToken    Zoom SDK app key.
    * @returns {Promise<any>}
    */
   @Cordova()
-  initialize(appKey: string, appSecret: string): Promise<any> {
+  initialize(jwtToken: string): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
The cordova.plugin.zoom is not maintained any more by Zoom Inc. I took their plugin and maintain it on an occasional basis, mostly when the currently supported Zoom library hits end of life.

The minimum required version required a breaking change, since the library must now be initialised with a JWT instead of the appKey and appSecret. (see https://developers.zoom.us/docs/meeting-sdk/auth/ ).

This pull-request contains the changes required to work with my current main branch of the Cordova plugin: https://gitlab.com/martin.ley/cordova.plugin.zoom
This plugin is not a turn-key ready plugin, since the zoom native libraries are not included for licensing reasons.
