### PR TITLE
fix(package): wrong top package main field

### DIFF
--- a/scripts/tasks/publish.ts
+++ b/scripts/tasks/publish.ts
@@ -15,7 +15,7 @@ const FLAGS = '--access public';
 
 const PACKAGE_JSON_BASE = {
   description: 'Awesome Cordova Plugins - Native plugins for ionic apps',
-  main: 'bundle.js',
+  main: 'index.js',
   module: 'index.js',
   typings: 'index.d.ts',
   author: 'ionic',


### PR DESCRIPTION
Related to this issue: https://github.com/danielsogl/awesome-cordova-plugins/issues/4714
Since the file bundle.js does not exist in the root directory we need to make index.js the main entry point. 