### PR TITLE
feat(cashfree-pg): support cordova-plugin-cashfree-pg 1.0.6

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/cashfree-pg/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/cashfree-pg/index.ts
@@ -219,6 +219,30 @@ export class CFWebCheckoutPayment implements CheckoutPayment {
   }
 }
 
+export class CFUPIIntentCheckoutPayment implements CheckoutPayment {
+  private readonly session: CFSession;
+  private readonly theme: CFTheme = new CFThemeBuilder().build();
+  version: string;
+
+  constructor(
+    session: CFSession,
+    theme: CFTheme | null
+  ) {
+    this.session = session;
+    if (theme !== null) {
+      this.theme = theme;
+    }
+  }
+
+  getSession() {
+    return this.session;
+  }
+
+  getTheme() {
+    return this.theme;
+  }
+}
+
 interface CFResult {
   orderID: string;
 }
@@ -262,6 +286,15 @@ export class CFPaymentGateway extends AwesomeCordovaNativePlugin {
    */
   @Cordova()
   doWebCheckoutPayment(webCheckoutPayment: CFWebCheckoutPayment) {
+    return;
+  }
+
+  /**
+   * Initiate UPI Checkout Payment.
+   * @param {CFUPIIntentCheckoutPayment} [upiCheckoutPayment] webCheckoutPaymentObject information
+   */
+  @Cordova()
+  doUPIPayment(upiCheckoutPayment: CFUPIIntentCheckoutPayment) {
     return;
   }
 


### PR DESCRIPTION
These are the iconic wrapping for the `cordova-plugin-cashfree-pg`. In this ,we are proving support for UPI Payment
This is our [Cordova SDK](https://www.npmjs.com/package/cordova-plugin-cashfree-pg)