### PR TITLE
fix(firebase-x): setConfigSettings function input parameters aligned with firebase-x plugin

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/firebase-x/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/firebase-x/index.ts
@@ -832,8 +832,8 @@ export class FirebaseX extends AwesomeCordovaNativePlugin {
   /**
    * Change the settings for the FirebaseRemoteConfig object's operations.
    *
-   * @param {object} fetchTimeout - fetch timeout in seconds. Default is 60 seconds.
-   * @param {string} minimumFetchInterval - minimum fetch inteval in seconds. Default is 12 hours.
+   * @param {number} fetchTimeout - fetch timeout in seconds. Default is 60 seconds.
+   * @param {number} minimumFetchInterval - minimum fetch inteval in seconds. Default is 12 hours.
    * @param {Function} success - callback function to be call on successfully setting the remote config settings
    * @param {Function} error - callback function which will be passed a {string} error message as an argument
    * @returns {Promise<any>}

--- a/src/@awesome-cordova-plugins/plugins/firebase-x/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/firebase-x/index.ts
@@ -116,7 +116,7 @@ export interface MessagePayloadAps {
   alert?: {
     title: string;
     body: string;
-  }
+  };
 }
 export interface MessagePayload {
   title?: string;
@@ -830,13 +830,21 @@ export class FirebaseX extends AwesomeCordovaNativePlugin {
   }
 
   /**
-   * Android only. Change the settings for the FirebaseRemoteConfig object's operations.
+   * Change the settings for the FirebaseRemoteConfig object's operations.
    *
-   * @param {Object} settings
+   * @param {object} fetchTimeout - fetch timeout in seconds. Default is 60 seconds.
+   * @param {string} minimumFetchInterval - minimum fetch inteval in seconds. Default is 12 hours.
+   * @param {Function} success - callback function to be call on successfully setting the remote config settings
+   * @param {Function} error - callback function which will be passed a {string} error message as an argument
    * @returns {Promise<any>}
    */
   @Cordova()
-  setConfigSettings(settings: any): Promise<any> {
+  setConfigSettings(
+    fetchTimeout: number,
+    minimumFetchInterval: number,
+    success: (res: string) => void,
+    error: (err: string) => void
+  ): Promise<any> {
     return;
   }
 

--- a/src/@awesome-cordova-plugins/plugins/firebase-x/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/firebase-x/index.ts
@@ -842,7 +842,7 @@ export class FirebaseX extends AwesomeCordovaNativePlugin {
   setConfigSettings(
     fetchTimeout: number,
     minimumFetchInterval: number,
-    success: (res: string) => void,
+    success: () => void,
     error: (err: string) => void
   ): Promise<any> {
     return;

--- a/src/@awesome-cordova-plugins/plugins/firebase-x/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/firebase-x/index.ts
@@ -836,7 +836,6 @@ export class FirebaseX extends AwesomeCordovaNativePlugin {
    * @param {number} minimumFetchInterval - minimum fetch inteval in seconds. Default is 12 hours.
    * @param {Function} success - callback function to be call on successfully setting the remote config settings
    * @param {Function} error - callback function which will be passed a {string} error message as an argument
-   * @returns {Promise<any>}
    */
   @Cordova()
   setConfigSettings(
@@ -844,7 +843,7 @@ export class FirebaseX extends AwesomeCordovaNativePlugin {
     minimumFetchInterval: number,
     success: () => void,
     error: (err: string) => void
-  ): Promise<any> {
+  ): void {
     return;
   }
 

--- a/src/@awesome-cordova-plugins/plugins/firebase/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/firebase/index.ts
@@ -267,15 +267,21 @@ export class Firebase extends AwesomeCordovaNativePlugin {
   }
 
   /**
-   * Change the settings for the FirebaseRemoteConfig object's operations
+   * Change the settings for the FirebaseRemoteConfig object's operations.
    *
-   * @param {Object} settings
+   * @param {object} fetchTimeout - fetch timeout in seconds. Default is 60 seconds.
+   * @param {string} minimumFetchInterval - minimum fetch inteval in seconds. Default is 12 hours.
+   * @param {Function} success - callback function to be call on successfully setting the remote config settings
+   * @param {Function} error - callback function which will be passed a {string} error message as an argument
    * @returns {Promise<any>}
    */
-  @Cordova({
-    platforms: ['Android'],
-  })
-  setConfigSettings(settings: any): Promise<any> {
+  @Cordova()
+  setConfigSettings(
+    fetchTimeout: number,
+    minimumFetchInterval: number,
+    success: (res: string) => void,
+    error: (err: string) => void
+  ): Promise<any> {
     return;
   }
 

--- a/src/@awesome-cordova-plugins/plugins/firebase/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/firebase/index.ts
@@ -267,21 +267,15 @@ export class Firebase extends AwesomeCordovaNativePlugin {
   }
 
   /**
-   * Change the settings for the FirebaseRemoteConfig object's operations.
+   * Change the settings for the FirebaseRemoteConfig object's operations
    *
-   * @param {object} fetchTimeout - fetch timeout in seconds. Default is 60 seconds.
-   * @param {string} minimumFetchInterval - minimum fetch inteval in seconds. Default is 12 hours.
-   * @param {Function} success - callback function to be call on successfully setting the remote config settings
-   * @param {Function} error - callback function which will be passed a {string} error message as an argument
+   * @param {Object} settings
    * @returns {Promise<any>}
    */
-  @Cordova()
-  setConfigSettings(
-    fetchTimeout: number,
-    minimumFetchInterval: number,
-    success: (res: string) => void,
-    error: (err: string) => void
-  ): Promise<any> {
+  @Cordova({
+    platforms: ['Android'],
+  })
+  setConfigSettings(settings: any): Promise<any> {
     return;
   }
 


### PR DESCRIPTION
Function `setConfigSettings` was using incorrect input arguments `settings: any` wheres [firebase-x cordova plugin doc](https://github.com/dpa99c/cordova-plugin-firebasex?tab=readme-ov-file#setconfigsettings) specifies correct arguments: 

**Parameters**:
- {integer} fetchTimeout - fetch timeout in seconds.
    - Default is 60 seconds.
    - Specify as `null` value to omit setting this value.
- {integer} minimumFetchInterval - minimum fetch inteval in seconds.
    - Default is 12 hours.
    - Specify as `null` value to omit setting this value.
    - Set to `0` to disable minimum interval entirely (**DO NOT** do this in production)
- {function} success - callback function to be call on successfully setting the remote config settings
- {function} error - callback function which will be passed a {string} error message as an argument