### PR TITLE
fix(facebook/fbsdk): fix typings for loginWithLimitedTracking

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/facebook/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/facebook/index.ts
@@ -15,6 +15,18 @@ export interface FacebookLoginResponse {
   };
 }
 
+export interface FacebookLimitedLoginResponse {
+  status: string;
+
+  authResponse: {
+    authenticationToken: string;
+
+    nonce: string;
+
+    userID: string;
+  };
+}
+
 /**
  * @name Facebook
  * @description
@@ -226,10 +238,11 @@ export class Facebook extends AwesomeCordovaNativePlugin {
    * ```
    *
    * @param {string[]}  permissions List of [permissions](https://developers.facebook.com/docs/facebook-login/limited-login/permissions) this app has upon logging in.
-   * @returns {Promise<FacebookLoginResponse>} Returns a Promise that resolves with a status object if login succeeds, and rejects if login fails.
+   * @param {string}    nonce       Nonce to create the configuration with.
+   * @returns {Promise<FacebookLimitedLoginResponse>} Returns a Promise that resolves with a status object if login succeeds, and rejects if login fails.
    */
   @Cordova()
-  loginWithLimitedTracking(permissions: string[]): Promise<FacebookLoginResponse> {
+  loginWithLimitedTracking(permissions: string[], nonce: string): Promise<FacebookLimitedLoginResponse> {
     return;
   }
 

--- a/src/@awesome-cordova-plugins/plugins/fbsdk/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/fbsdk/index.ts
@@ -15,6 +15,18 @@ export interface FbSdkLoginResponse {
   };
 }
 
+export interface FbSdkLimitedLoginResponse {
+  status: string;
+
+  authResponse: {
+    authenticationToken: string;
+
+    nonce: string;
+
+    userID: string;
+  };
+}
+
 /**
  * @name FbSdk
  * @description
@@ -231,10 +243,11 @@ export class FbSdk extends AwesomeCordovaNativePlugin {
    * ```
    *
    * @param {string[]}  permissions List of [permissions](https://developers.facebook.com/docs/facebook-login/limited-login/permissions) this app has upon logging in.
-   * @returns {Promise<FbSdkLoginResponse>} Returns a Promise that resolves with a status object if login succeeds, and rejects if login fails.
+   * @param {string}    nonce       Nonce to create the configuration with.
+   * @returns {Promise<FbSdkLimitedLoginResponse>} Returns a Promise that resolves with a status object if login succeeds, and rejects if login fails.
    */
   @Cordova()
-  loginWithLimitedTracking(permissions: string[]): Promise<FbSdkLoginResponse> {
+  loginWithLimitedTracking(permissions: string[], nonce: string): Promise<FbSdkLimitedLoginResponse> {
     return;
   }
 


### PR DESCRIPTION
Fixes the following for both old and new facebook plugin typings:
- Updates the return type for loginWithLimitedTracking to actually match the object returned
- Adds the `nonce` parameter which is required in the plugin.