### PR TITLE
fix(fingerprint-aio) : Added optional parameters to isAvailable()

### DIFF
--- a/src/@awesome-cordova-plugins/plugins/fingerprint-aio/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/fingerprint-aio/index.ts
@@ -239,6 +239,7 @@ export class FingerprintAIO extends AwesomeCordovaNativePlugin {
   /**
    * Check if fingerprint authentication is available
    *
+   * @param {FingerprintAvailableOptions} options Options for platform specific fingerprint API
    * @returns {Promise<BIOMETRIC_TYPE>} Returns a promise with result which depends on device and os.
    * iPhone X will return 'face' other Android or iOS devices will return 'finger' Android P+ will return 'biometric'
    */

--- a/src/@awesome-cordova-plugins/plugins/fingerprint-aio/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/fingerprint-aio/index.ts
@@ -244,7 +244,9 @@ export class FingerprintAIO extends AwesomeCordovaNativePlugin {
    * @returns {Promise<BIOMETRIC_TYPE>} Returns a promise with result which depends on device and os.
    * iPhone X will return 'face' other Android or iOS devices will return 'finger' Android P+ will return 'biometric'
    */
-  @Cordova()
+  @Cordova({
+    callbackOrder: 'reverse'
+  })
   isAvailable(options: FingerprintAvailableOptions): Promise<BIOMETRIC_TYPE> {
     return;
   }

--- a/src/@awesome-cordova-plugins/plugins/fingerprint-aio/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/fingerprint-aio/index.ts
@@ -157,6 +157,22 @@ export interface FingerprintSecretOptions extends FingerprintOptions {
   invalidateOnEnrollment?: boolean;
 }
 
+export interface FingerprintAvailableOptions {
+  /**
+  * (Android): If true will only return success if Class 3 (BIOMETRIC_STRONG) Biometrics are enrolled on the device. 
+  * It is reccomended you use this if planning on using the registerBiometricSecret and loadBiometricSecret methods.
+  */
+  requireStrongBiometrics: boolean;
+
+  /**
+  * (iOS): If true checks if backup authentication option is available, e.g. passcode. 
+  * Default: false, which means check for biometrics only.
+  * 
+  * @default false
+  */
+  allowBackup?: boolean;
+}
+
 /**
  * @name Fingerprint AIO
  * @description
@@ -227,7 +243,7 @@ export class FingerprintAIO extends AwesomeCordovaNativePlugin {
    * iPhone X will return 'face' other Android or iOS devices will return 'finger' Android P+ will return 'biometric'
    */
   @Cordova()
-  isAvailable(): Promise<BIOMETRIC_TYPE> {
+  isAvailable(options: FingerprintAvailableOptions): Promise<BIOMETRIC_TYPE> {
     return;
   }
 

--- a/src/@awesome-cordova-plugins/plugins/fingerprint-aio/index.ts
+++ b/src/@awesome-cordova-plugins/plugins/fingerprint-aio/index.ts
@@ -225,6 +225,7 @@ export interface FingerprintAvailableOptions {
  * @interfaces
  * FingerprintOptions
  * FingerprintSecretOptions
+ * FingerprintAvailableOptions
  */
 @Plugin({
   pluginName: 'FingerprintAIO',


### PR DESCRIPTION
Added two optional parameters to FingerprintAIO.isAvailable() to reflect the optional parameters of isAvailable() in cordova-plugin-fingerprint-aio https://github.com/NiklasMerz/cordova-plugin-fingerprint-aio?tab=readme-ov-file#optional-parameters

* requireStrongBiometrics
* allowBackup

Should correct issue #4881 